### PR TITLE
add cron build jobs for 3.14t-dev

### DIFF
--- a/.github/workflows/docker_image_cpython.yml
+++ b/.github/workflows/docker_image_cpython.yml
@@ -1,19 +1,19 @@
 name: Build cpython-tsan image
 
-#on:
-#  push:
-#    branches: [ "main" ]
-
 on:
   workflow_dispatch:
     inputs:
       python_version:
-        decription: Version of Python to build
-        default: 3.13t
+        description: Version of Python to build
+        default: '3.13t'
         type: choice
         options:
-        - 3.13t
-        - 3.14t
+        - '3.13t'
+        - '3.14t'
+        - '3.14t-dev'
+  schedule:
+    # 03:42 on Sundays and Wednesdays
+    - cron: "42 3 * * SUN,WED"
 
 jobs:
 
@@ -42,6 +42,6 @@ jobs:
        push: true
        file: ./Dockerfile.cpython
        build-args: |
-        python_version=${{ inputs.python_version }}
+        python_version=${{ inputs.python_version || '3.14t-dev' }}
        tags: |
-        ghcr.io/nascheme/cpython-tsan:${{ inputs.python_version }}
+        ghcr.io/nascheme/cpython-tsan:${{ inputs.python_version || '3.14t-dev' }}

--- a/.github/workflows/docker_image_numpy.yml
+++ b/.github/workflows/docker_image_numpy.yml
@@ -4,13 +4,16 @@ on:
   workflow_dispatch:
     inputs:
       python_version:
-        decription: Version of Python to build
-        default: 3.13t
+        description: Version of Python to build
+        default: '3.13t'
         type: choice
         options:
-        - 3.13t
-        - 3.14t
-
+        - '3.13t'
+        - '3.14t'
+        - '3.14t-dev'
+  schedule:
+    # 03:32 on Sundays and Wednesdays
+    - cron: "32 3 * * SUN,WED"
 
 jobs:
 
@@ -38,7 +41,7 @@ jobs:
        context: .
        push: true
        build-args: |
-        base_image=ghcr.io/nascheme/cpython-tsan:${{ inputs.python_version }}
+        base_image=ghcr.io/nascheme/cpython-tsan:${{ inputs.python_version || '3.14t-dev' }}
        file: ./Dockerfile.numpy
        tags: |
-        ghcr.io/nascheme/numpy-tsan:${{ inputs.python_version }}
+        ghcr.io/nascheme/numpy-tsan:${{ inputs.python_version || '3.14t-dev' }}

--- a/.github/workflows/docker_image_scipy.yml
+++ b/.github/workflows/docker_image_scipy.yml
@@ -4,12 +4,16 @@ on:
   workflow_dispatch:
     inputs:
       python_version:
-        decription: Version of Python to build
-        default: 3.13t
+        description: Version of Python to build
+        default: '3.13t'
         type: choice
         options:
-        - 3.13t
-        - 3.14t
+        - '3.13t'
+        - '3.14t'
+        - '3.14t-dev'
+  schedule:
+    # 03:52 on Sundays and Wednesdays
+    - cron: "52 3 * * SUN,WED"
 
 
 jobs:
@@ -38,7 +42,7 @@ jobs:
        context: .
        push: true
        build-args: |
-        base_image=ghcr.io/nascheme/numpy-tsan:${{ inputs.python_version }}
+        base_image=ghcr.io/nascheme/numpy-tsan:${{ inputs.python_version || '3.14t-dev' }}
        file: ./Dockerfile.scipy
        tags: |
-        ghcr.io/nascheme/scipy-tsan:${{ inputs.python_version }}
+        ghcr.io/nascheme/scipy-tsan:${{ inputs.python_version || '3.14t-dev' }}

--- a/README.md
+++ b/README.md
@@ -7,17 +7,23 @@ Free-threaded Python builds with TSAN enabled:
 
     ghcr.io/nascheme/cpython-tsan:3.13t
     ghcr.io/nascheme/cpython-tsan:3.14t
+    ghcr.io/nascheme/cpython-tsan:3.14t-dev
 
 Above builds with "numpy" compiled with TSAN as well:
 
     ghcr.io/nascheme/numpy-tsan:3.13t
     ghcr.io/nascheme/numpy-tsan:3.14t
+    ghcr.io/nascheme/numpy-tsan:3.14t-dev
 
 Above builds with "scipy" compiled with TSAN as well:
 
     ghcr.io/nascheme/scipy-tsan:3.13t
     ghcr.io/nascheme/scipy-tsan:3.14t
+    ghcr.io/nascheme/scipy-tsan:3.14t-dev
 
+
+The `3.14t-dev` images are rebuild twice a week by a cron job. The `3.13t` and
+`3.14t` images are rebuilt manually when Python releases happen.
 
 Hints
 -----


### PR DESCRIPTION
Adds 3.14t-dev as a `workflow_dispatch` option for all jobs and also sets up bi-weekly uploads. Note that cron jobs are disabled after 60 days of repository activity so someone will need to kick it every now and then.

CPython prereleases happen infrequently enough that I predict having more recent builds to check after bugfixes have been merged will be useful for some people.