### PR TITLE
fix: add llvm package to get llvm-symbolizer

### DIFF
--- a/Dockerfile.cpython
+++ b/Dockerfile.cpython
@@ -18,6 +18,7 @@ ca-certificates \
 clang-${LLVM_VERSION} \
 curl \
 git \
+llvm-${LLVM_VERSION} \
 libbz2-dev \
 libclang-rt-${LLVM_VERSION}-dev \
 libffi-dev \


### PR DESCRIPTION
Given the warning in #12, this is the most likely fix.

fix #12
